### PR TITLE
Added LinkedIn conversion tag

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -8,5 +8,16 @@
   </head>
   <body data-sveltekit-preload-data="hover">
     <div style="display: contents">%sveltekit.body%</div>
+    <! LinkedIn conversion tag -->
+    <script type="text/javascript"> _linkedin_partner_id = "5451473"; 
+    window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+     window._linkedin_data_partner_ids.push(_linkedin_partner_id);  
+    </script><script type="text/javascript"> (function(l) { if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])}; 
+      window.lintrk.q=[]} var s = document.getElementsByTagName("script")[0]; 
+      var b = document.createElement("script"); 
+      b.type = "text/javascript";b.async = true; 
+      b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js"; 
+      s.parentNode.insertBefore(b, s);})(window.lintrk); 
+      </script> <noscript> <img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=5451473&fmt=gif" /> </noscript>
   </body>
 </html>


### PR DESCRIPTION
## Description
- Adds LinkedIn conversion tag
- [See instructions on Linkedin.com](https://www.linkedin.com/help/lms/answer/a417886/use-event-specific-conversion-tracking-with-google-tag-manager?lang=en)

## Related Issue(s)
Fixes #111 

## How to test
<!-- Provide steps to test this PR -->
- Make sure website does not break
- Check status of conversion tracking in LinkedIn campaign manager [here](https://www.linkedin.com/campaignmanager/accounts/511755007/website-tracking/conversions/sources)