### PR TITLE
Fix .gitpod.yml start dev server race condition

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,9 +10,8 @@ ports:
 
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/configure/workspaces/tasks/
 tasks:
-  - name: Installing Dependencies
+  - name: Install Dependencies and Start Dev Server
     init: npm install
-  - name: Start Dev Server
     command: npm run dev
 
 github:


### PR DESCRIPTION
## Description
There's a race condition between the two tasks where the dev server is attempting to start before the dependencies are competed installation. This PR just combines them both into one task with the `init` and `command` together. 

## How to test
Start a gitpod workspace and the dev server should start automatically



<a href="https://gitpod.io/#https://github.com/gitpod-io/CDE-Universe/pull/152"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

